### PR TITLE
Fix interval handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/index.js
+++ b/index.js
@@ -4,12 +4,12 @@ var waitForSingleFileChange = (file, interval) =>
   new Promise(resolve => {
     var oldStats;
     var fileExists = true;
-    var checkFile = () => fs.stat(file, (err, stats) => {
-      if(err) {
+    var checkFile  = () => fs.stat(file, (err, stats) => {
+      if (err) {
         fileExists = false;
       } else {
-        if(fileExists) {
-          if(oldStats && (oldStats.ctime.getTime() !== stats.ctime.getTime() || oldStats.mtime.getTime() !== stats.mtime.getTime())) {
+        if (fileExists) {
+          if (oldStats && (oldStats.ctime.getTime() !== stats.ctime.getTime() || oldStats.mtime.getTime() !== stats.mtime.getTime())) {
             resolve(file);
           }
           oldStats = stats;

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -1,3 +1,4 @@
+"use strict";
 var fs = require("fs");
 var waitForChange = require("..");
 

--- a/wait-for-change.js
+++ b/wait-for-change.js
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 var waitForChange = require(".");
 
-waitForChange(process.argv.slice(2))
+// Check if an interval was provided, and take it if possible.
+var files = process.argv.slice(2);
+var interval;
+if (files.length > 1) {
+  var lastElement = files[files.length - 1];
+  if (/^\d+$/.test(lastElement)) { // Just to make sure the conversion would not fail
+    files.pop();
+    interval = Number(lastElement);
+  }
+}
+
+waitForChange(files, interval)
   .then(() => process.exit(0));


### PR DESCRIPTION
Interval always defaulted to 100, since there was no second argument to
the `waitForChange` call.
This commit checks if the last parameter of the arguments is a number,
and if it is, it's taken as the interval, and the rest as the files
array.
Detected while trying to calm down my dev-server a little bit when waiting for translations.